### PR TITLE
Add Vultr logo

### DIFF
--- a/src/components/ProviderIcon.tsx
+++ b/src/components/ProviderIcon.tsx
@@ -6,6 +6,7 @@ import {
   SiGooglecloud,
   SiMicrosoftazure,
   SiOracle,
+  SiVultr,
 } from "react-icons/si";
 import { MdOutlineQuestionMark } from "react-icons/md";
 
@@ -46,6 +47,9 @@ export const ProviderIcon = ({ provider }: { provider: ProviderKind }) => {
   }
   if (provider === ProviderKind.AZURE) {
     return <Icon as={SiMicrosoftazure} boxSize="1rem" />;
+  }
+  if (provider === ProviderKind.Vultr) {
+    return <Icon as={SiVultr} boxSize="1rem" alt="Vultr logo" />;
   }
   return <Icon as={MdOutlineQuestionMark} boxSize="1rem" />;
 };


### PR DESCRIPTION
Adds Vultr logo to entries with a Vultr provider

<img width="268" alt="Screenshot 2023-11-17 at 15 45 06" src="https://github.com/zeet-ai/gpucost/assets/894178/db81f72a-9791-4229-b56d-32a322c8657d">
